### PR TITLE
[FIX] MITM using https version

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,14 +1,14 @@
-var http = require('http');
+var https = require('https');
 var fs = require('fs');
 var path = require('path');
 var os = require('os');
 var unzip = require('unzip');
 
-var WIX_BINARY_URL = 'http://static.wixtoolset.org/releases/v3.9.1006.0/wix39-binaries.zip'
+var WIX_BINARY_URL = 'https://static.wixtoolset.org/releases/v3.9.1006.0/wix39-binaries.zip'
 
 var zipPath = path.resolve(os.tmpdir(), 'wix.zip');
 var file = fs.createWriteStream(zipPath);
-var request = http.get(WIX_BINARY_URL, function(response) {
+var request = https.get(WIX_BINARY_URL, function(response) {
 	response.pipe(file);
 	console.log('Downloading WIX Binaries');
 	response.on('data', function() {


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-wixtoolset

### ⚙️ Description *

A `zip file` is downloaded using a `unencrypted` and `insecure` channel, through `http`, being vulnerable against `MITM`.

### 💻 Technical Description *

I changed the `http` to `https` version and used the `https` library to request successfully the file :smile:

### 🐛 Proof of Concept (PoC) *

No needed

### 🔥 Proof of Fix (PoF) *

No needed

### 👍 User Acceptance Testing (UAT)

All ok and working :+1: 